### PR TITLE
[WIP] improvement in Bash scripts

### DIFF
--- a/benchmark/run_trex.sh
+++ b/benchmark/run_trex.sh
@@ -16,9 +16,9 @@ set -eu
 
 # define parameters using an array
 args=(
-  gene_tree_dir  # hey
-  output_fp      # look
-  verbose        # I can comment each parameter
+  gene_tree_dir        # directory containing gene trees
+  output_fp
+  verbose
   stdout
   stderr
   scripts_dir

--- a/benchmark/run_trex.sh
+++ b/benchmark/run_trex.sh
@@ -9,16 +9,39 @@
 # ----------------------------------------------------------------------------
 
 # usage: run T-REX software
-gene_tree_dir=$1
-output_fp=$2
-verbose=$3
-stdout=$4
-stderr=$5
-scripts_dir=$6
-species_tree_fp=$7
-input_file_nwk=$8
-trex_install_dir=$9
-base_input_file_nwk=${10}
+
+# -e: script will exit if any command fails
+# -u: force initialization of all variables
+set -eu
+
+# define parameters using an array
+args=(
+  gene_tree_dir  # hey
+  output_fp      # look
+  verbose        # I can comment each parameter
+  stdout
+  stderr
+  scripts_dir
+  species_tree_fp
+  input_file_nwk
+  trex_install_dir
+  base_input_file_nwk
+)
+
+# convert parameters to --longoptions
+arg_str=$(IFS=,; echo "${args[*]/%/:}" | tr '_' '-')
+
+# use GNU getopt to handle parameters
+TEMP=`getopt -o "" -l $arg_str -n "$0" -- "$@"`
+eval set -- "$TEMP"
+while true ; do
+  case "$1" in
+    # avoid re-writing parameter names
+    --?*) eval $(echo ${1:2} | tr '-' '_')=$2 ; shift 2 ;;
+    --) shift ; break ;;
+    *) echo "Internal error!" ; exit 1 ;;
+  esac
+done
 
 TIMEFORMAT='%U %R'
 total_user_time_trex="0.0"

--- a/benchmark/tests/test_simulate_hgts.py
+++ b/benchmark/tests/test_simulate_hgts.py
@@ -171,9 +171,7 @@ class SimulateHGTsTests(TestCase):
         """
         launch_orthofinder(self.proteomes_dir, 1, verbose=True)
         date = time.strftime("%c").split()
-        day = date[2]
-        if int(day) < 10:
-            day = "0%s" % day
+        day = date[2].zfill(2)
         results_dir = join(
             self.proteomes_dir, "Results_%s%s" % (date[1], day))
         orthogroups_exp = [['YP_002468181.1', 'YP_004590122.1'],


### PR DESCRIPTION
In this PR I demonstrated a new coding style for the Bash scripts (e.g., `run_program.sh`). During last code review, @josenavas and @wasade made multiple valuable comments, based on which I made these modifications. I only updated `run_trex.sh`. If the changes sounds good @ekopylova I will update other scripts as well.

One major problem of the current Bash scripts is that there are too many parameters (e.g., `launch_software.sh` has 29 parameters), and they are not sorted in a constant order. This will impose practical troubles to the users. To solve this problem I replaced the positional parameters with option-argument pairs (e.g., `--input-file /path/to/file.txt`). To achieve this I used [GNU getopt](https://www.gnu.org/software/libc/manual/html_node/Getopt.html), which is installed in most Linux systems by default. I designed a concise and elegant way to do the job, which I am quite proud of.

The second change is adding `set -eu` in the beginning of each script to handle runtime errors.

People also suggested to use GNU time to record time and memory consumption for benchmarking. But @wasade suggested that this applet is buggy in some circumstances, so I didn't use it for the moment.
