### PR TITLE
added collapsing functions

### DIFF
--- a/horizomer/utils/tests/test_tree.py
+++ b/horizomer/utils/tests/test_tree.py
@@ -90,114 +90,116 @@ class TreeTests(TestCase):
     def test_has_duplicates(self):
         """Test checking for duplicated taxa."""
         # test tree without duplicates
-        tree = '((a,b),(c,d));'
-        obs = has_duplicates(TreeNode.read([tree]))
+        tree = TreeNode.read(['((a,b),(c,d));'])
+        obs = has_duplicates(tree)
         self.assertFalse(obs)
 
         # test tree with duplicates
-        tree = '((a,a),(c,a));'
-        obs = has_duplicates(TreeNode.read([tree]))
+        tree = TreeNode.read(['((a,a),(c,a));'])
+        obs = has_duplicates(tree)
         self.assertTrue(obs)
 
-        tree = '((1,(2,x)),4,(5,(6,x,8)));'
-        obs = has_duplicates(TreeNode.read([tree]))
+        tree = TreeNode.read(['((1,(2,x)),4,(5,(6,x,8)));'])
+        obs = has_duplicates(tree)
         self.assertTrue(obs)
 
         # test tree with empty taxon names (not a common scenario but can
         # happen)
-        tree = '((1,(2,,)),4,(5,(6,,8)));'
+        tree = TreeNode.read(['((1,(2,,)),4,(5,(6,,8)));'])
         msg = 'Empty taxon name\(s\) found.'
         with self.assertRaisesRegex(ValueError, msg):
-            has_duplicates(TreeNode.read([tree]))
+            has_duplicates(tree)
 
     def test_compare_topology(self):
         """Test comparing topologies of two trees."""
         # test identical Newick strings
-        tree1 = '(a,b)c;'
-        tree2 = '(a,b)c;'
-        obs = compare_topology(TreeNode.read([tree1]), TreeNode.read([tree2]))
+        tree1 = TreeNode.read(['(a,b)c;'])
+        tree2 = TreeNode.read(['(a,b)c;'])
+        obs = compare_topology(tree1, tree2)
         self.assertTrue(obs)
 
         # test identical topologies with different branch lengths
-        tree1 = '(a:1,b:2)c:3;'
-        tree2 = '(a:3,b:2)c:1;'
-        obs = compare_topology(TreeNode.read([tree1]), TreeNode.read([tree2]))
+        tree1 = TreeNode.read(['(a:1,b:2)c:3;'])
+        tree2 = TreeNode.read(['(a:3,b:2)c:1;'])
+        obs = compare_topology(tree1, tree2)
         self.assertTrue(obs)
 
         # test identical topologies with flipped child nodes
-        tree1 = '(a,b)c;'
-        tree2 = '(b,a)c;'
-        obs = compare_topology(TreeNode.read([tree1]), TreeNode.read([tree2]))
+        tree1 = TreeNode.read(['(a,b)c;'])
+        tree2 = TreeNode.read(['(b,a)c;'])
+        obs = compare_topology(tree1, tree2)
         self.assertTrue(obs)
 
-        tree1 = '((4,5)2,(6,7,8)3)1;'
-        tree2 = '((8,7,6)3,(5,4)2)1;'
-        obs = compare_topology(TreeNode.read([tree1]), TreeNode.read([tree2]))
+        tree1 = TreeNode.read(['((4,5)2,(6,7,8)3)1;'])
+        tree2 = TreeNode.read(['((8,7,6)3,(5,4)2)1;'])
+        obs = compare_topology(tree1, tree2)
         self.assertTrue(obs)
 
-        tree1 = '(((9,10)4,(11,12,13)5)2,((14)6,(15,16,17,18)7,(19,20)8)3)1;'
-        tree2 = '(((15,16,17,18)7,(14)6,(20,19)8)3,((12,13,11)5,(10,9)4)2)1;'
-        obs = compare_topology(TreeNode.read([tree1]), TreeNode.read([tree2]))
+        tree1 = TreeNode.read(['(((9,10)4,(11,12,13)5)2,((14)6,(15,16,17,18)7,'
+                               '(19,20)8)3)1;'])
+        tree2 = TreeNode.read(['(((15,16,17,18)7,(14)6,(20,19)8)3,((12,13,11)5'
+                               ',(10,9)4)2)1;'])
+        obs = compare_topology(tree1, tree2)
         self.assertTrue(obs)
 
         # test different topologies
-        tree1 = '(a,b)c;'
-        tree2 = '(a,c)b;'
-        obs = compare_topology(TreeNode.read([tree1]), TreeNode.read([tree2]))
+        tree1 = TreeNode.read(['(a,b)c;'])
+        tree2 = TreeNode.read(['(a,c)b;'])
+        obs = compare_topology(tree1, tree2)
         self.assertFalse(obs)
 
-        tree1 = '((4,5)2,(6,7,8)3)1;'
-        tree2 = '((4,5)3,(6,7,8)2)1;'
-        obs = compare_topology(TreeNode.read([tree1]), TreeNode.read([tree2]))
+        tree1 = TreeNode.read(['((4,5)2,(6,7,8)3)1;'])
+        tree2 = TreeNode.read(['((4,5)3,(6,7,8)2)1;'])
+        obs = compare_topology(tree1, tree2)
         self.assertFalse(obs)
 
-        tree1 = '((4,5)2,(6,7,8)3)1;'
-        tree2 = '(((4,1)8)7,(6,3)2)5;'
-        obs = compare_topology(TreeNode.read([tree1]), TreeNode.read([tree2]))
+        tree1 = TreeNode.read(['((4,5)2,(6,7,8)3)1;'])
+        tree2 = TreeNode.read(['(((4,1)8)7,(6,3)2)5;'])
+        obs = compare_topology(tree1, tree2)
         self.assertFalse(obs)
 
     def test_intersect_trees(self):
         """Test intersecting two trees."""
         # test trees with identical taxa
-        tree1 = '((a,b),(c,d));'
-        tree2 = '(a,(b,c,d));'
-        obs = intersect_trees(TreeNode.read([tree1]), TreeNode.read([tree2]))
-        exp = (TreeNode.read([tree1]), TreeNode.read([tree2]))
+        tree1 = TreeNode.read(['((a,b),(c,d));'])
+        tree2 = TreeNode.read(['(a,(b,c,d));'])
+        obs = intersect_trees(tree1, tree2)
+        exp = (tree1, tree2)
         for i in range(2):
             self.assertEqual(obs[i].compare_subsets(exp[i]), 0.0)
 
         # test trees with partially different taxa
-        tree1 = '((a,b),(c,d));'
-        tree2 = '((a,b),(c,e));'
-        obs = intersect_trees(TreeNode.read([tree1]), TreeNode.read([tree2]))
-        tree1_lap = '((a,b),c);'
-        tree2_lap = '((a,b),e);'
-        exp = (TreeNode.read([tree1_lap]), TreeNode.read([tree2_lap]))
+        tree1 = TreeNode.read(['((a,b),(c,d));'])
+        tree2 = TreeNode.read(['((a,b),(c,e));'])
+        obs = intersect_trees(tree1, tree2)
+        tree1_lap = TreeNode.read(['((a,b),c);'])
+        tree2_lap = TreeNode.read(['((a,b),e);'])
+        exp = (tree1_lap, tree2_lap)
         for i in range(2):
             self.assertEqual(obs[i].compare_subsets(exp[i]), 0.0)
 
-        tree1 = '(((a,b),(c,d)),((e,f,g),h));'
-        tree2 = '(a,((b,x),(d,y,(f,g,h))));'
-        obs = intersect_trees(TreeNode.read([tree1]), TreeNode.read([tree2]))
-        tree1_lap = '(((a,b),d),((f,g),h));'
-        tree2_lap = '(a,(b,(d,(f,g,h))));'
-        exp = (TreeNode.read([tree1_lap]), TreeNode.read([tree2_lap]))
+        tree1 = TreeNode.read(['(((a,b),(c,d)),((e,f,g),h));'])
+        tree2 = TreeNode.read(['(a,((b,x),(d,y,(f,g,h))));'])
+        obs = intersect_trees(tree1, tree2)
+        tree1_lap = TreeNode.read(['(((a,b),d),((f,g),h));'])
+        tree2_lap = TreeNode.read(['(a,(b,(d,(f,g,h))));'])
+        exp = (tree1_lap, tree2_lap)
         for i in range(2):
             self.assertEqual(obs[i].compare_subsets(exp[i]), 0.0)
 
         # test trees with completely different taxa
-        tree1 = '((a,b),(c,d));'
-        tree2 = '((e,f),(g,h));'
+        tree1 = TreeNode.read(['((a,b),(c,d));'])
+        tree2 = TreeNode.read(['((e,f),(g,h));'])
         msg = 'Trees have no overlapping taxa.'
         with self.assertRaisesRegex(ValueError, msg):
-            intersect_trees(TreeNode.read([tree1]), TreeNode.read([tree2]))
+            intersect_trees(tree1, tree2)
 
         # test trees with duplicated taxa
-        tree1 = '((a,b),(c,d));'
-        tree2 = '((a,a),(b,c));'
+        tree1 = TreeNode.read(['((a,b),(c,d));'])
+        tree2 = TreeNode.read(['((a,a),(b,c));'])
         msg = 'Either tree has duplicated taxa.'
         with self.assertRaisesRegex(ValueError, msg):
-            intersect_trees(TreeNode.read([tree1]), TreeNode.read([tree2]))
+            intersect_trees(tree1, tree2)
 
     def test_collapse_short_branches(self):
         """Test collapsing short branches."""

--- a/horizomer/utils/tests/test_tree.py
+++ b/horizomer/utils/tests/test_tree.py
@@ -15,8 +15,8 @@ from os.path import join, dirname, realpath
 from skbio import TreeNode
 
 from horizomer.utils.tree import (
-    support, collapse, has_duplicates, compare_topology, intersect_trees,
-    collapse_short_branches, collapse_low_support_nodes,
+    support, unpack, has_duplicates, compare_topology, intersect_trees,
+    unpack_short_branches, unpack_low_support_nodes,
     read_taxdump, build_taxdump_tree)
 
 
@@ -67,25 +67,25 @@ class TreeTests(TestCase):
         for node in tree.children:
             self.assertIsNone(support(node))
 
-    def test_collapse(self):
-        """Test collapsing an internal node."""
-        # test collapsing a node without branch length
+    def test_unpack(self):
+        """Test unpacking an internal node."""
+        # test unpacking a node without branch length
         tree = TreeNode.read(['((c,d)a,(e,f)b);'])
-        collapse(tree.find('b'))
+        unpack(tree.find('b'))
         exp = '((c,d)a,e,f);\n'
         self.assertEqual(str(tree), exp)
 
-        # test collapsing a node with branch length
+        # test unpacking a node with branch length
         tree = TreeNode.read(['((c:2.0,d:3.0)a:1.0,(e:2.0,f:1.0)b:2.0);'])
-        collapse(tree.find('b'))
+        unpack(tree.find('b'))
         exp = '((c:2.0,d:3.0)a:1.0,e:4.0,f:3.0);'
         self.assertEqual(str(tree).rstrip(), exp)
 
-        # test attempting to collapse root
+        # test attempting to unpack root
         tree = TreeNode.read(['((d,e)b,(f,g)c)a;'])
-        msg = 'Cannot collapse root.'
+        msg = 'Cannot unpack root.'
         with self.assertRaisesRegex(ValueError, msg):
-            collapse(tree.find('a'))
+            unpack(tree.find('a'))
 
     def test_has_duplicates(self):
         """Test checking for duplicated taxa."""
@@ -201,59 +201,59 @@ class TreeTests(TestCase):
         with self.assertRaisesRegex(ValueError, msg):
             intersect_trees(tree1, tree2)
 
-    def test_collapse_short_branches(self):
-        """Test collapsing short branches."""
-        # collapse internal nodes with branch length < 1.01
-        # (will collapse node 'a', but not tip 'e')
+    def test_unpack_short_branch_nodes(self):
+        """Test unpacking short branches."""
+        # unpack internal nodes with branch length < 1.01
+        # (will unpack node 'a', but not tip 'e')
         # (will add the branch length of 'a' to its child nodes 'c' and 'd')
         tree = TreeNode.read(['((c:2,d:3)a:1,(e:1,f:2)b:2);'])
-        obs = str(collapse_short_branches(tree, 1.01)).rstrip()
+        obs = str(unpack_short_branch_nodes(tree, 1.01)).rstrip()
         exp = '((e:1.0,f:2.0)b:2.0,c:3.0,d:4.0);'
         self.assertEqual(obs, exp)
 
-        # collapse internal nodes with branch length < 2.01
-        # (will collapse both 'a' and 'b')
-        obs = str(collapse_short_branches(tree, 2.01)).rstrip()
+        # unpack internal nodes with branch length < 2.01
+        # (will unpack both 'a' and 'b')
+        obs = str(unpack_short_branch_nodes(tree, 2.01)).rstrip()
         exp = '(c:3.0,d:4.0,e:3.0,f:4.0);'
         self.assertEqual(obs, exp)
 
-        # collapse two nested nodes 'a' and 'c' simultaneously
+        # unpack two nested nodes 'a' and 'c' simultaneously
         tree = TreeNode.read(['(((e:3,f:2)c:1,d:3)a:1,b:4);'])
-        obs = str(collapse_short_branches(tree, 2.01)).rstrip()
+        obs = str(unpack_short_branch_nodes(tree, 2.01)).rstrip()
         exp = '(b:4.0,d:4.0,e:5.0,f:4.0);'
         self.assertEqual(obs, exp)
 
-        # collapse internal node 'a' which has no branch length
+        # unpack internal node 'a' which has no branch length
         tree = TreeNode.read(['((c:2,d:3)a,(e:1,f:2)b:2);'])
-        obs = str(collapse_short_branches(tree, 1.01)).rstrip()
+        obs = str(unpack_short_branch_nodes(tree, 1.01)).rstrip()
         exp = '((e:1.0,f:2.0)b:2.0,c:2.0,d:3.0);'
         self.assertEqual(obs, exp)
 
-        # test a complicated scenario (collapsing nodes 'g', 'h' and 'm')
+        # test a complicated scenario (unpacking nodes 'g', 'h' and 'm')
         tree = TreeNode.read(['(((a:1.04,b:2.32,c:1.44)d:3.20,'
                               '(e:3.91,f:2.47)g:1.21)h:1.75,'
                               '(i:4.14,(j:2.06,k:1.58)l:3.32)m:0.77);'])
-        obs = str(collapse_short_branches(tree, 2.01)).rstrip()
+        obs = str(unpack_short_branch_nodes(tree, 2.01)).rstrip()
         exp = ('((a:1.04,b:2.32,c:1.44)d:4.95,e:6.87,f:5.43,i:4.91,'
                '(j:2.06,k:1.58)l:4.09);')
         self.assertEqual(obs, exp)
 
-    def test_collapse_low_support_nodes(self):
-        """Test collapsing low-support nodes."""
-        # collapse nodes with support < 75
+    def test_unpack_low_support_nodes(self):
+        """Test unpacking low-support nodes."""
+        # unpack nodes with support < 75
         tree = TreeNode.read(['(((a,b)85,(c,d)78)75,(e,(f,g)64)80);'])
-        obs = str(collapse_low_support_nodes(tree, 75)).rstrip()
+        obs = str(unpack_low_support_nodes(tree, 75)).rstrip()
         exp = '(((a,b)85,(c,d)78)75,(e,f,g)80);'
         self.assertEqual(obs, exp)
 
-        # collapse nodes with support < 85
-        obs = str(collapse_low_support_nodes(tree, 85)).rstrip()
+        # unpack nodes with support < 85
+        obs = str(unpack_low_support_nodes(tree, 85)).rstrip()
         exp = '((a,b)85,c,d,e,f,g);'
         self.assertEqual(obs, exp)
 
-        # collapse nodes with support < 0.95
+        # unpack nodes with support < 0.95
         tree = TreeNode.read(['(((a,b)0.97,(c,d)0.98)1.0,(e,(f,g)0.88)0.96);'])
-        obs = str(collapse_low_support_nodes(tree, 0.95)).rstrip()
+        obs = str(unpack_low_support_nodes(tree, 0.95)).rstrip()
         exp = '(((a,b)0.97,(c,d)0.98)1.0,(e,f,g)0.96);'
         self.assertEqual(obs, exp)
 
@@ -262,7 +262,7 @@ class TreeTests(TestCase):
         tree = TreeNode.read(['(((a:1.02,b:0.33)85:0.12,(c:0.86,d:2.23)'
                               '70:3.02)75:0.95,(e:1.43,(f:1.69,g:1.92)64:0.20)'
                               'node:0.35)root;'])
-        obs = str(collapse_low_support_nodes(tree, 75)).rstrip()
+        obs = str(unpack_low_support_nodes(tree, 75)).rstrip()
         exp = ('(((a:1.02,b:0.33)85:0.12,c:3.88,d:5.25)75:0.95,'
                '(e:1.43,f:1.89,g:2.12)node:0.35)root;')
         self.assertEqual(obs, exp)

--- a/horizomer/utils/tests/test_tree.py
+++ b/horizomer/utils/tests/test_tree.py
@@ -16,8 +16,7 @@ from skbio import TreeNode
 
 from horizomer.utils.tree import (
     support, unpack, has_duplicates, compare_topology, intersect_trees,
-    unpack_by_func, unpack_short_branch_nodes, unpack_low_support_nodes,
-    read_taxdump, build_taxdump_tree)
+    unpack_by_func, read_taxdump, build_taxdump_tree)
 
 
 class TreeTests(TestCase):
@@ -265,72 +264,6 @@ class TreeTests(TestCase):
                               '70:3.02)75:0.95,(e:1.43,(f:1.69,g:1.92)64:0.20)'
                               'node:0.35)root;'])
         obs = str(unpack_by_func(tree, func)).rstrip()
-        exp = ('(((a:1.02,b:0.33)85:0.12,c:3.88,d:5.25)75:0.95,'
-               '(e:1.43,f:1.89,g:2.12)node:0.35)root;')
-        self.assertEqual(obs, exp)
-
-    def test_unpack_short_branch_nodes(self):
-        """Test unpacking short branches."""
-        # unpack internal nodes with branch length < 1.01
-        # (will unpack node 'a', but not tip 'e')
-        # (will add the branch length of 'a' to its child nodes 'c' and 'd')
-        tree = TreeNode.read(['((c:2,d:3)a:1,(e:1,f:2)b:2);'])
-        obs = str(unpack_short_branch_nodes(tree, 1.01)).rstrip()
-        exp = '((e:1.0,f:2.0)b:2.0,c:3.0,d:4.0);'
-        self.assertEqual(obs, exp)
-
-        # unpack internal nodes with branch length < 2.01
-        # (will unpack both 'a' and 'b')
-        obs = str(unpack_short_branch_nodes(tree, 2.01)).rstrip()
-        exp = '(c:3.0,d:4.0,e:3.0,f:4.0);'
-        self.assertEqual(obs, exp)
-
-        # unpack two nested nodes 'a' and 'c' simultaneously
-        tree = TreeNode.read(['(((e:3,f:2)c:1,d:3)a:1,b:4);'])
-        obs = str(unpack_short_branch_nodes(tree, 2.01)).rstrip()
-        exp = '(b:4.0,d:4.0,e:5.0,f:4.0);'
-        self.assertEqual(obs, exp)
-
-        # unpack internal node 'a' which has no branch length
-        tree = TreeNode.read(['((c:2,d:3)a,(e:1,f:2)b:2);'])
-        obs = str(unpack_short_branch_nodes(tree, 1.01)).rstrip()
-        exp = '((e:1.0,f:2.0)b:2.0,c:2.0,d:3.0);'
-        self.assertEqual(obs, exp)
-
-        # test a complicated scenario (unpacking nodes 'g', 'h' and 'm')
-        tree = TreeNode.read(['(((a:1.04,b:2.32,c:1.44)d:3.20,'
-                              '(e:3.91,f:2.47)g:1.21)h:1.75,'
-                              '(i:4.14,(j:2.06,k:1.58)l:3.32)m:0.77);'])
-        obs = str(unpack_short_branch_nodes(tree, 2.01)).rstrip()
-        exp = ('((a:1.04,b:2.32,c:1.44)d:4.95,e:6.87,f:5.43,i:4.91,'
-               '(j:2.06,k:1.58)l:4.09);')
-        self.assertEqual(obs, exp)
-
-    def test_unpack_low_support_nodes(self):
-        """Test unpacking low-support nodes."""
-        # unpack nodes with support < 75
-        tree = TreeNode.read(['(((a,b)85,(c,d)78)75,(e,(f,g)64)80);'])
-        obs = str(unpack_low_support_nodes(tree, 75)).rstrip()
-        exp = '(((a,b)85,(c,d)78)75,(e,f,g)80);'
-        self.assertEqual(obs, exp)
-
-        # unpack nodes with support < 85
-        obs = str(unpack_low_support_nodes(tree, 85)).rstrip()
-        exp = '((a,b)85,c,d,e,f,g);'
-        self.assertEqual(obs, exp)
-
-        # unpack nodes with support < 0.95
-        tree = TreeNode.read(['(((a,b)0.97,(c,d)0.98)1.0,(e,(f,g)0.88)0.96);'])
-        obs = str(unpack_low_support_nodes(tree, 0.95)).rstrip()
-        exp = '(((a,b)0.97,(c,d)0.98)1.0,(e,f,g)0.96);'
-        self.assertEqual(obs, exp)
-
-        # test a case where there are branch lengths, none support values add
-        # node labels
-        tree = TreeNode.read(['(((a:1.02,b:0.33)85:0.12,(c:0.86,d:2.23)'
-                              '70:3.02)75:0.95,(e:1.43,(f:1.69,g:1.92)64:0.20)'
-                              'node:0.35)root;'])
-        obs = str(unpack_low_support_nodes(tree, 75)).rstrip()
         exp = ('(((a:1.02,b:0.33)85:0.12,c:3.88,d:5.25)75:0.95,'
                '(e:1.43,f:1.89,g:2.12)node:0.35)root;')
         self.assertEqual(obs, exp)

--- a/horizomer/utils/tests/test_tree.py
+++ b/horizomer/utils/tests/test_tree.py
@@ -16,7 +16,7 @@ from skbio import TreeNode
 
 from horizomer.utils.tree import (
     support, unpack, has_duplicates, compare_topology, intersect_trees,
-    unpack_short_branch_nodes, unpack_low_support_nodes,
+    unpack_by_func, unpack_short_branch_nodes, unpack_low_support_nodes,
     read_taxdump, build_taxdump_tree)
 
 
@@ -200,6 +200,74 @@ class TreeTests(TestCase):
         msg = 'Either tree has duplicated taxa.'
         with self.assertRaisesRegex(ValueError, msg):
             intersect_trees(tree1, tree2)
+
+    def test_unpack_by_func(self):
+        """Test unpacking nodes by function."""
+        # unpack internal nodes with branch length <= 1.0
+        def func(x):
+            return x.length <= 1.0
+
+        # will unpack node 'a', but not tip 'e'
+        # will add the branch length of 'a' to its child nodes 'c' and 'd'
+        tree = TreeNode.read(['((c:2,d:3)a:1,(e:1,f:2)b:2);'])
+        obs = str(unpack_by_func(tree, func)).rstrip()
+        exp = '((e:1.0,f:2.0)b:2.0,c:3.0,d:4.0);'
+        self.assertEqual(obs, exp)
+
+        # unpack internal nodes with branch length < 2.01
+        # will unpack both 'a' and 'b'
+        obs = str(unpack_by_func(tree, lambda x: x.length <= 2.0)).rstrip()
+        exp = '(c:3.0,d:4.0,e:3.0,f:4.0);'
+        self.assertEqual(obs, exp)
+
+        # unpack two nested nodes 'a' and 'c' simultaneously
+        tree = TreeNode.read(['(((e:3,f:2)c:1,d:3)a:1,b:4);'])
+        obs = str(unpack_by_func(tree, lambda x: x.length <= 2.0)).rstrip()
+        exp = '(b:4.0,d:4.0,e:5.0,f:4.0);'
+        self.assertEqual(obs, exp)
+
+        # test a complicated scenario (unpacking nodes 'g', 'h' and 'm')
+        def func(x):
+            return x.length < 2.0
+        tree = TreeNode.read(['(((a:1.04,b:2.32,c:1.44)d:3.20,'
+                              '(e:3.91,f:2.47)g:1.21)h:1.75,'
+                              '(i:4.14,(j:2.06,k:1.58)l:3.32)m:0.77);'])
+        obs = str(unpack_by_func(tree, func)).rstrip()
+        exp = ('((a:1.04,b:2.32,c:1.44)d:4.95,e:6.87,f:5.43,i:4.91,'
+               '(j:2.06,k:1.58)l:4.09);')
+        self.assertEqual(obs, exp)
+
+        # unpack nodes with support < 75
+        def func(x):
+            return support(x) < 75
+        tree = TreeNode.read(['(((a,b)85,(c,d)78)75,(e,(f,g)64)80);'])
+        obs = str(unpack_by_func(tree, func)).rstrip()
+        exp = '(((a,b)85,(c,d)78)75,(e,f,g)80);'
+        self.assertEqual(obs, exp)
+
+        # unpack nodes with support < 85
+        obs = str(unpack_by_func(tree, lambda x: support(x) < 85)).rstrip()
+        exp = '((a,b)85,c,d,e,f,g);'
+        self.assertEqual(obs, exp)
+
+        # unpack nodes with support < 0.95
+        tree = TreeNode.read(['(((a,b)0.97,(c,d)0.98)1.0,(e,(f,g)0.88)0.96);'])
+        obs = str(unpack_by_func(tree, lambda x: support(x) < 0.95)).rstrip()
+        exp = '(((a,b)0.97,(c,d)0.98)1.0,(e,f,g)0.96);'
+        self.assertEqual(obs, exp)
+
+        # test a case where there are branch lengths, none support values and
+        # node labels
+        def func(x):
+            sup = support(x)
+            return sup is not None and sup < 75
+        tree = TreeNode.read(['(((a:1.02,b:0.33)85:0.12,(c:0.86,d:2.23)'
+                              '70:3.02)75:0.95,(e:1.43,(f:1.69,g:1.92)64:0.20)'
+                              'node:0.35)root;'])
+        obs = str(unpack_by_func(tree, func)).rstrip()
+        exp = ('(((a:1.02,b:0.33)85:0.12,c:3.88,d:5.25)75:0.95,'
+               '(e:1.43,f:1.89,g:2.12)node:0.35)root;')
+        self.assertEqual(obs, exp)
 
     def test_unpack_short_branch_nodes(self):
         """Test unpacking short branches."""

--- a/horizomer/utils/tests/test_tree.py
+++ b/horizomer/utils/tests/test_tree.py
@@ -15,8 +15,9 @@ from os.path import join, dirname, realpath
 from skbio import TreeNode
 
 from horizomer.utils.tree import (
-    has_duplicates, compare_topology, intersect_trees, read_taxdump,
-    build_taxdump_tree)
+    support, collapse, has_duplicates, compare_topology, intersect_trees,
+    collapse_short_branches, collapse_low_support_nodes,
+    read_taxdump, build_taxdump_tree)
 
 
 class TreeTests(TestCase):
@@ -39,6 +40,53 @@ class TreeTests(TestCase):
         # but in the future there will be
         rmtree(self.working_dir)
 
+    def test_support(self):
+        """Test getting support value of a node."""
+        # test nodes with support alone as label
+        tree = TreeNode.read(['((a,b)75,(c,d)90);'])
+        node1, node2 = tree.children
+        self.assertEqual(support(node1), 75.0)
+        self.assertEqual(support(node2), 90.0)
+
+        # test nodes with support and branch length
+        tree = TreeNode.read(['((a,b)0.85:1.23,(c,d)0.95:4.56);'])
+        node1, node2 = tree.children
+        self.assertEqual(support(node1), 0.85)
+        self.assertEqual(support(node2), 0.95)
+
+        # test nodes with support and extra label (not a common scenario but
+        # can happen)
+        tree = TreeNode.read(['((a,b)\'80:X\',(c,d)\'60:Y\');'])
+        node1, node2 = tree.children
+        self.assertEqual(support(node1), 80.0)
+        self.assertEqual(support(node2), 60.0)
+
+        # test nodes without label, with non-numeric label, and with branch
+        # length only
+        tree = TreeNode.read(['((a,b),(c,d)x,(e,f):1.0);'])
+        for node in tree.children:
+            self.assertIsNone(support(node))
+
+    def test_collapse(self):
+        """Test collapsing an internal node."""
+        # test collapsing a node without branch length
+        tree = TreeNode.read(['((c,d)a,(e,f)b);'])
+        collapse(tree.find('b'))
+        exp = '((c,d)a,e,f);\n'
+        self.assertEqual(str(tree), exp)
+
+        # test collapsing a node with branch length
+        tree = TreeNode.read(['((c:2.0,d:3.0)a:1.0,(e:2.0,f:1.0)b:2.0);'])
+        collapse(tree.find('b'))
+        exp = '((c:2.0,d:3.0)a:1.0,e:4.0,f:3.0);'
+        self.assertEqual(str(tree).rstrip(), exp)
+
+        # test attempting to collapse root
+        tree = TreeNode.read(['((d,e)b,(f,g)c)a;'])
+        msg = 'Cannot collapse root.'
+        with self.assertRaisesRegex(ValueError, msg):
+            collapse(tree.find('a'))
+
     def test_has_duplicates(self):
         """Test checking for duplicated taxa."""
         # test tree without duplicates
@@ -55,7 +103,8 @@ class TreeTests(TestCase):
         obs = has_duplicates(TreeNode.read([tree]))
         self.assertTrue(obs)
 
-        # test tree with empty taxon names
+        # test tree with empty taxon names (not a common scenario but can
+        # happen)
         tree = '((1,(2,,)),4,(5,(6,,8)));'
         msg = 'Empty taxon name\(s\) found.'
         with self.assertRaisesRegex(ValueError, msg):
@@ -149,6 +198,72 @@ class TreeTests(TestCase):
         msg = 'Either tree has duplicated taxa.'
         with self.assertRaisesRegex(ValueError, msg):
             intersect_trees(TreeNode.read([tree1]), TreeNode.read([tree2]))
+
+    def test_collapse_short_branches(self):
+        """Test collapsing short branches."""
+        # collapse internal nodes with branch length < 1.01
+        # (will collapse node 'a', but not tip 'e')
+        # (will add the branch length of 'a' to its child nodes 'c' and 'd')
+        tree = TreeNode.read(['((c:2,d:3)a:1,(e:1,f:2)b:2);'])
+        obs = str(collapse_short_branches(tree, 1.01)).rstrip()
+        exp = '((e:1.0,f:2.0)b:2.0,c:3.0,d:4.0);'
+        self.assertEqual(obs, exp)
+
+        # collapse internal nodes with branch length < 2.01
+        # (will collapse both 'a' and 'b')
+        obs = str(collapse_short_branches(tree, 2.01)).rstrip()
+        exp = '(c:3.0,d:4.0,e:3.0,f:4.0);'
+        self.assertEqual(obs, exp)
+
+        # collapse two nested nodes 'a' and 'c' simultaneously
+        tree = TreeNode.read(['(((e:3,f:2)c:1,d:3)a:1,b:4);'])
+        obs = str(collapse_short_branches(tree, 2.01)).rstrip()
+        exp = '(b:4.0,d:4.0,e:5.0,f:4.0);'
+        self.assertEqual(obs, exp)
+
+        # collapse internal node 'a' which has no branch length
+        tree = TreeNode.read(['((c:2,d:3)a,(e:1,f:2)b:2);'])
+        obs = str(collapse_short_branches(tree, 1.01)).rstrip()
+        exp = '((e:1.0,f:2.0)b:2.0,c:2.0,d:3.0);'
+        self.assertEqual(obs, exp)
+
+        # test a complicated scenario (collapsing nodes 'g', 'h' and 'm')
+        tree = TreeNode.read(['(((a:1.04,b:2.32,c:1.44)d:3.20,'
+                              '(e:3.91,f:2.47)g:1.21)h:1.75,'
+                              '(i:4.14,(j:2.06,k:1.58)l:3.32)m:0.77);'])
+        obs = str(collapse_short_branches(tree, 2.01)).rstrip()
+        exp = ('((a:1.04,b:2.32,c:1.44)d:4.95,e:6.87,f:5.43,i:4.91,'
+               '(j:2.06,k:1.58)l:4.09);')
+        self.assertEqual(obs, exp)
+
+    def test_collapse_low_support_nodes(self):
+        """Test collapsing low-support nodes."""
+        # collapse nodes with support < 75
+        tree = TreeNode.read(['(((a,b)85,(c,d)78)75,(e,(f,g)64)80);'])
+        obs = str(collapse_low_support_nodes(tree, 75)).rstrip()
+        exp = '(((a,b)85,(c,d)78)75,(e,f,g)80);'
+        self.assertEqual(obs, exp)
+
+        # collapse nodes with support < 85
+        obs = str(collapse_low_support_nodes(tree, 85)).rstrip()
+        exp = '((a,b)85,c,d,e,f,g);'
+        self.assertEqual(obs, exp)
+
+        # collapse nodes with support < 0.95
+        tree = TreeNode.read(['(((a,b)0.97,(c,d)0.98)1.0,(e,(f,g)0.88)0.96);'])
+        obs = str(collapse_low_support_nodes(tree, 0.95)).rstrip()
+        exp = '(((a,b)0.97,(c,d)0.98)1.0,(e,f,g)0.96);'
+        self.assertEqual(obs, exp)
+
+        # test a case where there are branch lengths, none support values add
+        # node labels
+        tree = TreeNode.read(['(((a:1.02,b:0.33)85:0.12,(c:0.86,d:2.23)'
+                              '70:3.02)75:0.95,(e:1.43,(f:1.69,g:1.92)64:0.20)'
+                              'node:0.35)root;'])
+        obs = str(collapse_low_support_nodes(tree, 75)).rstrip()
+        exp = ('(((a:1.02,b:0.33)85:0.12,c:3.88,d:5.25)75:0.95,'
+               '(e:1.43,f:1.89,g:2.12)node:0.35)root;')
+        self.assertEqual(obs, exp)
 
     def test_read_taxdump(self):
         """Test reading NCBI taxdump."""

--- a/horizomer/utils/tests/test_tree.py
+++ b/horizomer/utils/tests/test_tree.py
@@ -16,7 +16,7 @@ from skbio import TreeNode
 
 from horizomer.utils.tree import (
     support, unpack, has_duplicates, compare_topology, intersect_trees,
-    unpack_short_branches, unpack_low_support_nodes,
+    unpack_short_branch_nodes, unpack_low_support_nodes,
     read_taxdump, build_taxdump_tree)
 
 

--- a/horizomer/utils/tree.py
+++ b/horizomer/utils/tree.py
@@ -43,13 +43,13 @@ def support(node):
         return None
 
 
-def collapse(node):
-    """Collapse an internal node of a tree.
+def unpack(node):
+    """Unpack an internal node of a tree.
 
     Parameters
     ----------
     node : skbio.TreeNode
-        node to collapse
+        node to unpack
 
     Notes
     -----
@@ -57,7 +57,7 @@ def collapse(node):
     self (omit if there is no branch length), 2) removes self from parent node,
     and 3) grafts child nodes to parent node.
 
-    Here is an illustration of the "collapse" operation:
+    Here is an illustration of the "unpack" operation:
                 /----a
           /c---|
          |      \--b
@@ -66,7 +66,7 @@ def collapse(node):
           \f-----|
                   \-e
 
-    Collapse node "c" and the tree becomes:
+    Unpack node "c" and the tree becomes:
           /---------a
          |
     -----|--------b
@@ -76,7 +76,7 @@ def collapse(node):
                   \-e
     """
     if node.is_root():
-        raise ValueError('Cannot collapse root.')
+        raise ValueError('Cannot unpack root.')
     parent = node.parent
     blen = (node.length or 0.0)
     for child in node.children:
@@ -162,63 +162,63 @@ def intersect_trees(tree1, tree2):
     return (tree1_lap, tree2_lap)
 
 
-def collapse_short_branches(tree, cutoff):
-    """Collapse internal nodes with branch length below cutoff.
+def unpack_short_branch_nodes(tree, cutoff):
+    """Unpack internal nodes with branch length below cutoff.
 
     Parameters
     ----------
     tree : skbio.TreeNode
-        tree to search for nodes to collapse
+        tree to search for nodes to unpack
     cutoff : int or float
-        branch length cutoff under which node should be collapsed
+        branch length cutoff under which node should be unpackd
 
     Returns
     -------
     skbio.TreeNode
-        resulting tree with short branches collapsed
+        resulting tree with short branches unpackd
 
     Notes
     -------
     Nodes without branch length are considered as having zero branch length and
-    will be collapsed.
+    will be unpackd.
     """
     tcopy = tree.copy()
-    nodes_to_collapse = []
+    nodes_to_unpack = []
     for node in tcopy.non_tips():
         if (node.length or 0.0) < cutoff:
-            nodes_to_collapse.append(node)
-    for node in nodes_to_collapse:
-        collapse(node)
+            nodes_to_unpack.append(node)
+    for node in nodes_to_unpack:
+        unpack(node)
     return tcopy
 
 
-def collapse_low_support_nodes(tree, cutoff):
-    """Collapse internal nodes with support value below cutoff.
+def unpack_low_support_nodes(tree, cutoff):
+    """Unpack internal nodes with support value below cutoff.
 
     Parameters
     ----------
     tree : skbio.TreeNode
-        tree to search for nodes to collapse
+        tree to search for nodes to unpack
     cutoff : int or float
-        node support value cutoff under which it should be collapsed
+        node support value cutoff under which it should be unpackd
 
     Returns
     -------
     skbio.TreeNode
-        resulting tree with low-support nodes collapsed
+        resulting tree with low-support nodes unpackd
 
     Notes
     -------
-    Nodes without support value will NOT be collapsed.
+    Nodes without support value will NOT be unpackd.
     """
     tcopy = tree.copy()
-    nodes_to_collapse = []
+    nodes_to_unpack = []
     for node in tcopy.non_tips():
         spt = support(node)
         if spt is not None and spt < cutoff:
-            nodes_to_collapse.append(node)
-    for node in nodes_to_collapse:
-        collapse(node)
+            nodes_to_unpack.append(node)
+    for node in nodes_to_unpack:
+        unpack(node)
     return tcopy
 
 

--- a/horizomer/utils/tree.py
+++ b/horizomer/utils/tree.py
@@ -162,6 +162,32 @@ def intersect_trees(tree1, tree2):
     return (tree1_lap, tree2_lap)
 
 
+def unpack_by_func(tree, func):
+    """Unpack internal nodes that meet certain criteria.
+
+    Parameters
+    ----------
+    tree : skbio.TreeNode
+        tree to search for nodes to unpack
+    func : function
+        a function that accepts a TreeNode and returns `True` or `False`,
+        where `True` indicates the node is to be unpacked
+
+    Returns
+    -------
+    skbio.TreeNode
+        resulting tree with nodes meeting criteria unpacked
+    """
+    tcopy = tree.copy()
+    nodes_to_unpack = []
+    for node in tcopy.non_tips():
+        if func(node):
+            nodes_to_unpack.append(node)
+    for node in nodes_to_unpack:
+        unpack(node)
+    return tcopy
+
+
 def unpack_short_branch_nodes(tree, cutoff):
     """Unpack internal nodes with branch length below cutoff.
 

--- a/horizomer/utils/tree.py
+++ b/horizomer/utils/tree.py
@@ -56,6 +56,24 @@ def collapse(node):
     This function sequentially: 1) elongates child nodes by branch length of
     self (omit if there is no branch length), 2) removes self from parent node,
     and 3) grafts child nodes to parent node.
+
+    Here is an illustration of the "collapse" operation:
+                /----a
+          /c---|
+         |      \--b
+    -----|
+         |        /---d
+          \f-----|
+                  \-e
+
+    Collapse node "c" and the tree becomes:
+          /---------a
+         |
+    -----|--------b
+         |
+         |        /---d
+          \f-----|
+                  \-e
     """
     if node.is_root():
         raise ValueError('Cannot collapse root.')

--- a/horizomer/utils/tree.py
+++ b/horizomer/utils/tree.py
@@ -188,66 +188,6 @@ def unpack_by_func(tree, func):
     return tcopy
 
 
-def unpack_short_branch_nodes(tree, cutoff):
-    """Unpack internal nodes with branch length below cutoff.
-
-    Parameters
-    ----------
-    tree : skbio.TreeNode
-        tree to search for nodes to unpack
-    cutoff : int or float
-        branch length cutoff under which node should be unpackd
-
-    Returns
-    -------
-    skbio.TreeNode
-        resulting tree with short branches unpackd
-
-    Notes
-    -------
-    Nodes without branch length are considered as having zero branch length and
-    will be unpackd.
-    """
-    tcopy = tree.copy()
-    nodes_to_unpack = []
-    for node in tcopy.non_tips():
-        if (node.length or 0.0) < cutoff:
-            nodes_to_unpack.append(node)
-    for node in nodes_to_unpack:
-        unpack(node)
-    return tcopy
-
-
-def unpack_low_support_nodes(tree, cutoff):
-    """Unpack internal nodes with support value below cutoff.
-
-    Parameters
-    ----------
-    tree : skbio.TreeNode
-        tree to search for nodes to unpack
-    cutoff : int or float
-        node support value cutoff under which it should be unpackd
-
-    Returns
-    -------
-    skbio.TreeNode
-        resulting tree with low-support nodes unpackd
-
-    Notes
-    -------
-    Nodes without support value will NOT be unpackd.
-    """
-    tcopy = tree.copy()
-    nodes_to_unpack = []
-    for node in tcopy.non_tips():
-        spt = support(node)
-        if spt is not None and spt < cutoff:
-            nodes_to_unpack.append(node)
-    for node in nodes_to_unpack:
-        unpack(node)
-    return tcopy
-
-
 def read_taxdump(nodes_fp, names_fp=None):
     """Read NCBI taxdump.
 


### PR DESCRIPTION
Four very useful functions, the latter two of which depend on the former two, and will be important in generating reliable reference trees. They themselves are very simple. But the logics behind them need some consideration.
 - get node support value
 - collapse a node
 - collapse all nodes with branch length < cutoff
 - collapse all nodes with support value < cutoff